### PR TITLE
Circleci with pip dist setup.cfg contained

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+orbs:
+  python: circleci/python@2.0.3
+
+workflows:
+  test:
+    jobs:
+      - python/test:
+          pkg-manager: pip-dist
+          pip-dependency-file: requirements-dev.txt
+          # unrelated to anything else, just making sure
+          # the pip and poetry build jobs don't collide their cache
+          cache-version: v100

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ workflows:
     jobs:
       - python/test:
           pkg-manager: pip-dist
-          pip-dependency-file: requirements-dev.txt
+          pip-dependency-file: setup.cfg
+          args: --editable .[dev]
           # unrelated to anything else, just making sure
           # the pip and poetry build jobs don't collide their cache
           cache-version: v100

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,7 @@ description = Just a test for CircleCI
 [options]
 packages = find:
 python_requires = >=3.8,<3.11
+
+[options.extras_require]
+dev =
+    pytest


### PR DESCRIPTION
Make all dependencies contained in 'setup.cfg'

This means our caching should now work fine, but requires passing an
extra arg.